### PR TITLE
Project page order

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to Registry
+    if: github.event_name != 'pull_request'
     runs-on: self-hosted
     steps:
       - name: Set up QEMU

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to GitLab Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: registry.gitlab.uni-bonn.de:5050
@@ -26,9 +25,8 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v3
         with:
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           provenance: false
           tags: registry.gitlab.uni-bonn.de:5050/rpl/containers/website:latest
       - name: Image digest
-        if: github.event_name != 'pull_request'
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to Registry
-    if: github.event_name != 'pull_request'
     runs-on: self-hosted
     steps:
       - name: Set up QEMU
@@ -17,6 +16,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to GitLab Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: registry.gitlab.uni-bonn.de:5050
@@ -26,8 +26,9 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v3
         with:
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           provenance: false
           tags: registry.gitlab.uni-bonn.de:5050/rpl/containers/website:latest
       - name: Image digest
+        if: github.event_name != 'pull_request'
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/src/pages/student-projects.js
+++ b/src/pages/student-projects.js
@@ -4,6 +4,31 @@ import { graphql } from "gatsby";
 
 export const Head = () => <title>Open Student Projects - Robot Perception and Learning Lab</title>;
 
+const projectDatePattern = /^(\d{4})-(\d{2})-(\d{2})/;
+
+function getProjectTimestamp(project) {
+  const dateMatch = project.name.match(projectDatePattern);
+
+  if (!dateMatch) {
+    return 0;
+  }
+
+  const [, year, month, day] = dateMatch;
+  return Date.UTC(Number(year), Number(month) - 1, Number(day));
+}
+
+function compareProjectsNewestFirst(projectA, projectB) {
+  const dateDifference =
+    getProjectTimestamp(projectB) - getProjectTimestamp(projectA);
+
+  if (dateDifference !== 0) {
+    return dateDifference;
+  }
+
+  return projectA.childMarkdownRemark.frontmatter.title.localeCompare(
+    projectB.childMarkdownRemark.frontmatter.title
+  );
+}
 
 export const query = graphql`
   query PaperQuery {
@@ -33,7 +58,11 @@ export const query = graphql`
 `;
 
 const StudentProjects = ({ data }) => {
-  console.log(data);
+  const projects = data.allFile.nodes
+    .filter((node) => node.childMarkdownRemark)
+    .filter((node) => node.childMarkdownRemark.frontmatter.visible)
+    .sort(compareProjectsNewestFirst);
+
   return (
     <>
       <div className="section pb-0">
@@ -51,9 +80,7 @@ const StudentProjects = ({ data }) => {
       <div className="section">
         <div className="container">
           <div className="row mt-2 mb-2">
-            {data.allFile.nodes
-              .filter((node) => node.childMarkdownRemark)
-              .filter((node) => node.childMarkdownRemark.frontmatter.visible)
+            {projects
               .map((project) => (
                 <div className="col-sm-6 mb-2 mt-2 mb-sm-0" key={project.id}>
                   <div className="card">


### PR DESCRIPTION
## Summary

- Sort visible student project cards by the date prefix in their markdown filename.
- Keep newest dated projects first and place undated projects last.
- Remove the debug `console.log` from the student projects page.

## Validation

- Checked the rendered `/student-projects/` HTML order locally.
- Built successfully earlier with Node 22, matching the repo Dockerfile: `npx -y -p node@22 node ./node_modules/gatsby-cli/cli.js build`.